### PR TITLE
feat: caching for Rector and PHPStan

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,5 +46,21 @@ jobs:
       - name: Generate Application Key
         run: php artisan key:generate
 
+      - name: Rector Cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/rector
+          key: ${{ runner.os }}-rector-${{ hashFiles('composer.lock') }}
+          restore-keys: ${{ runner.os }}-rector-
+      - run: mkdir -p /tmp/rector
+
+      - name: PHPStan Cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/phpstan
+          key: ${{ runner.os }}-phpstan-${{ hashFiles('composer.lock') }}
+          restore-keys: ${{ runner.os }}-phpstan-
+      - run: mkdir -p /tmp/phpstan
+
       - name: Tests
         run: composer test

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,3 +8,6 @@ parameters:
         - app/
 
     level: max
+
+    
+    tmpDir: /tmp/phpstan

--- a/rector.php
+++ b/rector.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-use Rector\Config\RectorConfig;
 use Rector\Caching\ValueObject\Storage\FileCacheStorage;
+use Rector\Config\RectorConfig;
 use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
 
 return RectorConfig::configure()

--- a/rector.php
+++ b/rector.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\Caching\ValueObject\Storage\FileCacheStorage;
 use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
 
 return RectorConfig::configure()

--- a/rector.php
+++ b/rector.php
@@ -6,6 +6,10 @@ use Rector\Config\RectorConfig;
 use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
 
 return RectorConfig::configure()
+    ->withCache(
+        cacheDirectory: '/tmp/rector',
+        cacheClass: FileCacheStorage::class,
+    )
     ->withPaths([
         __DIR__.'/app',
         __DIR__.'/bootstrap/app.php',


### PR DESCRIPTION
This PR introduces caching for Rector and PHPStan and added caching for CI as recommended by their official documentation.

Rector Cache in CI:
https://getrector.com/documentation/cache-in-ci

PHPStan Cache in CI:
https://phpstan.org/user-guide/result-cache#setup-in-github-actions

Especially when the code base grows, this makes these tests so much faster locally and also in CI.