### PR TITLE
fix(mcp): remove hard-coded paths and allow safe commands to always run.

### DIFF
--- a/.junie/mcp/mcp.json
+++ b/.junie/mcp/mcp.json
@@ -1,10 +1,27 @@
 {
     "mcpServers": {
         "laravel-boost": {
-            "command": "/Users/nunomaduro/Library/Application Support/Herd/bin/php84",
+            "command": "php",
             "args": [
-                "/Users/nunomaduro/Work/projects/nunomaduro/laravel-starter-kit/artisan",
+                "artisan",
                 "boost:mcp"
+            ],
+            "alwaysAllow": [
+                "application-info",
+                "browser-logs",
+                "database-connections",
+                "database-query",
+                "database-schema",
+                "get-absolute-url",
+                "get-config",
+                "last-error",
+                "list-artisan-commands",
+                "list-available-config-keys",
+                "list-available-env-vars",
+                "list-routes",
+                "read-log-entries",
+                "report-feedback",
+                "search-docs"
             ]
         }
     }


### PR DESCRIPTION
This pull request updates the `.junie/mcp/mcp.json` configuration to simplify the `laravel-boost` server command and enhance its capabilities by explicitly allowing a set of commands. The most important changes are:

Configuration simplification:
* Changed the `command` for `laravel-boost` from an absolute path to simply `php`, and updated the `args` to use the relative `artisan` path, improving portability and ease of use.

Command permissions:
* Added an `alwaysAllow` list specifying which commands are always permitted for the `laravel-boost` server, including commands related to application info, logs, database, configuration, routes, and documentation search.