### PR TITLE
Chore: adds `tmp` diractory to ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ yarn-error.log
 /.nova
 /.vscode
 /.zed
+/tmp

--- a/pint.json
+++ b/pint.json
@@ -1,7 +1,8 @@
 {
     "preset": "laravel",
     "notPath": [
-        "tests/TestCase.php"
+        "tests/TestCase.php",
+        "tmp"
     ],
     "rules": {
         "array_push": true,


### PR DESCRIPTION
This pull request makes a minor update to the `pint.json` configuration file to exclude the `tmp` directory from code formatting. This helps prevent unnecessary formatting of temporary files during code linting.
And also add it to `.gitignore`.