### PR TITLE
fix: remove redundant config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -92,7 +92,6 @@
         }
     },
     "config": {
-        "bump-after-update": true,
         "optimize-autoloader": true,
         "preferred-install": "dist",
         "sort-packages": true,


### PR DESCRIPTION
Hi Nuno, 

i think in composer.json this config "bump-after-update": true" is redundant, because "composer bump" is already used in "post-update-cmd" -> "update:requirements".