### PR TITLE
chore: Simplify root route using Route::view

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Route;
 
-Route::get('/', fn (): View => view('welcome'));
+Route::view('/', 'welcome');


### PR DESCRIPTION
### Summary

This PR simplifies the root route definition in the starter kit by using `Route::view` instead of a closure.  
It’s a minor refactor aimed at making the route definition more concise and readable.

### Before

```php
<?php

declare(strict_types=1);

use Illuminate\Contracts\View\View;
use Illuminate\Support\Facades\Route;

Route::get('/', fn (): View => view('welcome'));
```

### After

```php
<?php

declare(strict_types=1);

use Illuminate\Support\Facades\Route;

Route::view('/', 'welcome');
```