### PR TITLE
refactor: import class names rector rule

### DIFF
--- a/config/auth.php
+++ b/config/auth.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use App\Models\User;
+
 return [
 
     /*
@@ -64,7 +66,7 @@ return [
     'providers' => [
         'users' => [
             'driver' => 'eloquent',
-            'model' => env('AUTH_MODEL', App\Models\User::class),
+            'model' => env('AUTH_MODEL', User::class),
         ],
 
         // 'users' => [

--- a/config/essentials.php
+++ b/config/essentials.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use NunoMaduro\Essentials\Configurables\Unguard;
+
 return [
-    NunoMaduro\Essentials\Configurables\Unguard::class => true,
+    Unguard::class => true,
 ];

--- a/rector.php
+++ b/rector.php
@@ -22,6 +22,9 @@ return RectorConfig::configure()
         LaravelSetList::LARAVEL_IF_HELPERS,
         LaravelSetList::LARAVEL_LEGACY_FACTORIES_TO_CLASSES,
     ])
+    ->withImportNames(
+        removeUnusedImports: true,
+    )
     ->withComposerBased(laravel: true)
     ->withCache(
         cacheDirectory: '/tmp/rector',

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -2,12 +2,14 @@
 
 declare(strict_types=1);
 
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Sleep;
 use Illuminate\Support\Str;
+use Tests\TestCase;
 
-pest()->extend(Tests\TestCase::class)
-    ->use(Illuminate\Foundation\Testing\RefreshDatabase::class)
+pest()->extend(TestCase::class)
+    ->use(RefreshDatabase::class)
     ->beforeEach(function (): void {
         Str::createRandomStringsNormally();
         Str::createUuidsNormally();


### PR DESCRIPTION
This PR introduces Rectors [Import Names](https://getrector.com/documentation/import-names) rule.

It automatically simplifies `FQNs` and puts an import use statement on top and it also  removes unused and dead imports.

```diff
<?php

+use App\Models\User;
-use App\Models\UnusedModel;

-$user = new \App\Models\User();
+$user = new User();
```