### PR TITLE
chore: bump dependencies to latest versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,23 +10,23 @@
     "license": "MIT",
     "require": {
         "php": "^8.4.0",
-        "laravel/framework": "^12.33.0",
+        "laravel/framework": "^12.46.0",
         "nunomaduro/essentials": "^1.0.1"
     },
     "require-dev": {
-        "driftingly/rector-laravel": "^2.0.7",
+        "driftingly/rector-laravel": "^2.1.9",
         "fakerphp/faker": "^1.24.1",
-        "larastan/larastan": "^3.7.2",
-        "laravel/boost": "^1.3.0",
-        "laravel/pail": "^1.2.3",
-        "laravel/pint": "^1.25.1",
+        "larastan/larastan": "^3.8.1",
+        "laravel/boost": "^1.8.9",
+        "laravel/pail": "^1.2.4",
+        "laravel/pint": "^1.27.0",
         "mockery/mockery": "^1.6.12",
-        "nunomaduro/collision": "^8.8.2",
-        "pestphp/pest": "^4.1.2",
-        "pestphp/pest-plugin-browser": "^4.1.1",
+        "nunomaduro/collision": "^8.8.3",
+        "pestphp/pest": "^4.3.1",
+        "pestphp/pest-plugin-browser": "^4.2.0",
         "pestphp/pest-plugin-laravel": "^4.0.0",
-        "pestphp/pest-plugin-type-coverage": "^4.0.2",
-        "rector/rector": "^2.2.2"
+        "pestphp/pest-plugin-type-coverage": "^4.0.3",
+        "rector/rector": "^2.3.0"
     },
     "autoload": {
         "psr-4": {

--- a/package.json
+++ b/package.json
@@ -8,15 +8,15 @@
         "test:lint": "prettier --check resources/"
     },
     "devDependencies": {
-        "@tailwindcss/vite": "^4.1.14",
+        "@tailwindcss/vite": "^4.1.18",
         "concurrently": "^9.2.1",
         "laravel-vite-plugin": "^2.0.1",
-        "npm-check-updates": "^19.0.0",
-        "playwright": "^1.56.0",
-        "prettier": "^3.6.2",
+        "npm-check-updates": "^19.3.1",
+        "playwright": "^1.57.0",
+        "prettier": "^3.7.4",
         "prettier-plugin-organize-imports": "^4.3.0",
-        "prettier-plugin-tailwindcss": "^0.6.14",
-        "tailwindcss": "^4.1.14",
-        "vite": "^7.1.9"
+        "prettier-plugin-tailwindcss": "^0.7.2",
+        "tailwindcss": "^4.1.18",
+        "vite": "^7.3.1"
     }
 }


### PR DESCRIPTION
chore: update dependencies

- Bump Laravel framework from ^12.33.0 to ^12.46.0
- Update dev dependencies (rector-laravel, larastan, laravel/boost, pest, etc.)
- Update frontend dependencies (tailwindcss, vite, prettier, playwright, etc.)