### PR TITLE
docs: update readme to link to Vue kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 - Blade (this project) version: **[github.com/nunomaduro/laravel-starter-kit](https://github.com/nunomaduro/laravel-starter-kit)**
 - Inertia & React version: **[github.com/nunomaduro/laravel-starter-kit-inertia-react](https://github.com/nunomaduro/laravel-starter-kit-inertia-react)**
+- Inertia & Vue version: **[github.com/nunomaduro/laravel-starter-kit-inertia-vue](https://github.com/nunomaduro/laravel-starter-kit-inertia-vue)**
 
 
 <p align="center">
@@ -33,7 +34,7 @@ This isn't just another Laravel boilerplate—it's a statement that PHP applicat
 
 ## Getting Started
 
-> **Requires [PHP 8.4+](https://php.net/releases/)**, and [Bun](https://bun.sh).
+> **Requires [PHP 8.4+](https://php.net/releases/)**, [Bun](https://bun.sh) and a code coverage driver like [xdebug](https://xdebug.org/docs/install)**.
 
 Create your type-safe Laravel application using [Composer](https://getcomposer.org):
 


### PR DESCRIPTION
Updates to the readme to link to the Vue starter kit and to add the code coverage driver to the requirements, as it is on the React kit readme.