### PR TITLE
chore: Add Laravel preset to ArchTest

### DIFF
--- a/tests/Unit/ArchTest.php
+++ b/tests/Unit/ArchTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 arch()->preset()->php();
 arch()->preset()->strict();
+arch()->preset()->laravel();
 arch()->preset()->security()->ignoring([
     'assert',
 ]);


### PR DESCRIPTION
Quick PR to add the laravel preset to the arch test. 

See discussion here: https://github.com/nunomaduro/laravel-starter-kit-inertia-vue/issues/2