### PR TITLE
feat: update to use oxfmt vs Prettier

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,32 @@
+{
+    "printWidth": 80,
+    "tabWidth": 4,
+    "useTabs": false,
+    "semi": true,
+    "singleQuote": true,
+    "overrides": [
+        {
+            "files": ["**/*.yml"],
+            "options": {
+                "tabWidth": 2
+            }
+        }
+    ],
+    "sortTailwindcss": {
+        "functions": ["clsx", "cn"],
+        "stylesheet": "resources/css/app.css"
+    },
+    "sortImports": {
+        "groups": [
+            "builtin",
+            "external",
+            "internal",
+            "parent",
+            "sibling",
+            "index"
+        ],
+        "newlinesBetween": false
+    },
+    "$schema": "./node_modules/oxfmt/configuration_schema.json",
+    "ignorePatterns": ["resources/views/mail/*"]
+}

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ You should see 100% test coverage and all quality checks passing.
 - `composer dev` - Starts Laravel server, queue worker, log monitoring, and Vite dev server concurrently
 
 ### Code Quality
-- `composer lint` - Runs Rector (refactoring), Pint (PHP formatting), and Prettier (JS/TS formatting)
+- `composer lint` - Runs Rector (refactoring), Pint (PHP formatting), and Oxfmt (JS/TS formatting)
 - `composer test:lint` - Dry-run mode for CI/CD pipelines
 
 ### Testing

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Override;
 
 /**
  * @property-read string $id
@@ -33,6 +34,7 @@ final class User extends Authenticatable implements MustVerifyEmail
     /**
      * @var list<string>
      */
+    #[Override]
     protected $hidden = [
         'password',
         'remember_token',

--- a/package.json
+++ b/package.json
@@ -4,18 +4,16 @@
     "scripts": {
         "build": "vite build",
         "dev": "vite",
-        "lint": "prettier --write resources/",
-        "test:lint": "prettier --check resources/"
+        "lint": "oxfmt resources/",
+        "test:lint": "oxfmt --check resources/"
     },
     "devDependencies": {
         "@tailwindcss/vite": "^4.1.18",
         "concurrently": "^9.2.1",
         "laravel-vite-plugin": "^2.1.0",
         "npm-check-updates": "^19.3.2",
+        "oxfmt": "^0.35.0",
         "playwright": "^1.58.2",
-        "prettier": "^3.8.1",
-        "prettier-plugin-organize-imports": "^4.3.0",
-        "prettier-plugin-tailwindcss": "^0.7.2",
         "tailwindcss": "^4.1.18",
         "vite": "^7.3.1"
     }

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,4 +1,4 @@
-@import "tailwindcss";
+@import 'tailwindcss';
 
 @source '../../vendor/laravel/framework/src/Illuminate/Pagination/resources/views/*.blade.php';
 @source '../../storage/framework/views/*.php';
@@ -8,7 +8,7 @@
 
 @theme {
     --font-sans:
-        "Instrument Sans", ui-sans-serif, system-ui, sans-serif,
-        "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
-        "Noto Color Emoji";
+        'Instrument Sans', ui-sans-serif, system-ui, sans-serif,
+        'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
+        'Noto Color Emoji';
 }


### PR DESCRIPTION
Adds oxfmt to replace prettier as a more modern and more performant solution. Update the import sorter to match the rules in the recently updated Laravel starter kits. For ref: https://github.com/laravel/vue-starter-kit/blob/main/eslint.config.js

This follows the same oxfmt config as the Laravel starter kits had in prettier and matches the changes created on the Vue and React kits.